### PR TITLE
Create Security document for reporting private issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a **security vulnerability**, please **do not** open a public issue. Instead, use one of the following **confidential contact methods**:
 
-* **GitHub:** Click the Security tab, then Report a Vulnerability and fill out the advisory details form.
+* **GitHub:** Click the [Security tab](https://github.com/Fabulously-Optimized/fabulously-optimized/security), then [Report a vulnerability](https://github.com/Fabulously-Optimized/fabulously-optimized/security/advisories/new) and fill out the advisory details form.
 * **Discord:** Join our [Discord server](https://discord.gg/fabulously-optimized-859124104644788234) and visit the [#modmail](https://discord.com/channels/859124104644788234/1092684323515273247) channel for further instructions.
 
-If your issue is **not security-related** (e.g., bug reports, feature requests, or usage questions), please use the [GitHub Issues page](https://github.com/Fabulously-Optimized/fabulously-optimized/issues) or contact us via the [Discord server](https://discord.gg/fabulously-optimized-859124104644788234).
+If your issue is **not security-related** (e.g., bug reports, feature requests, or usage questions), please use the [Issues tab](https://github.com/Fabulously-Optimized/fabulously-optimized/issues) or use a relevant channel in the [Discord server](https://discord.gg/fabulously-optimized-859124104644788234).


### PR DESCRIPTION
Adds security document for reporting private issues in terms of Fabulously Optimized in general,
Resolves GitHub's community standards checklist which is currently 6 out of 8.