### PR TITLE
Mitigate security vulnerabilities in CI

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: github-actions
     permissions:
-      id-token: write
-      attestations: write
+      id-token: read
       contents: write
     steps:
        - name: Download pack files
@@ -37,7 +36,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: github-actions
     permissions:
-      id-token: write
+      id-token: read
       attestations: write
       contents: write
     steps:

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -5,7 +5,7 @@ on:
   - delete
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   sync-bitbucket:


### PR DESCRIPTION
1. Adds permission system for `publish-to-curseforge` and the git-repo-sync workflow as only `publish-to-modrinth` has it - However use `write` if the workflow absolutely [requires it](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents),
2. Pins all job versions to their commit hashes to avoid [supply chain attacks towards the workflow script](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash),
3. Moves all environment mentions into the `env:` section to prevent causing them from getting expanded into attacker-controllable code.

*(These security issues were spotted by the `zizmor` library)*