### PR TITLE
Set CI timeout to 30 mins

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,6 +6,7 @@ jobs:
   publish-to-curseforge:
     if: github.repository_owner == 'Fabulously-Optimized'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     environment: github-actions
     permissions:
       id-token: write
@@ -34,6 +35,7 @@ jobs:
   publish-to-modrinth:
     if: github.repository_owner == 'Fabulously-Optimized'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     environment: github-actions
     permissions:
       id-token: write

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -11,6 +11,7 @@ jobs:
   sync-bitbucket:
     if: github.repository_owner == 'Fabulously-Optimized'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     name: Git Repo Sync - BitBucket
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
Adds the `timeout-minutes` to the job(s) section so that the CI doesn't take 6 hours straight to get aborted in case something is causing the CI to suddenly stall or become unresponsive. *(this can be adjusted if 30 mins is too short or too long)*